### PR TITLE
feat(commands, error_queue): implement 'SYSTem:ERRor:ALL?'

### DIFF
--- a/microscpi-macros/src/lib.rs
+++ b/microscpi-macros/src/lib.rs
@@ -311,6 +311,14 @@ pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
             handler: CommandHandler::StandardFunction("ErrorCommands::system_error_count"),
             future: false,
         });
+
+        command_set.push(CommandDefinition {
+            id: None,
+            args: Vec::new(),
+            command: Command::try_from("SYSTem:ERRor:ALL?").unwrap(),
+            handler: CommandHandler::StandardFunction("ErrorCommands::system_error_all"),
+            future: false,
+        });
     }
 
     if config.status_commands {

--- a/microscpi-macros/src/tree.rs
+++ b/microscpi-macros/src/tree.rs
@@ -28,7 +28,7 @@ impl std::fmt::Display for Error {
 type NodeId = usize;
 
 /// Represents a tree of SCPI commands.
-/// 
+///
 /// The tree is used to efficiently look up command handlers based on the parsed command string.
 /// It maps each component of a command path to the appropriate handler function.
 pub struct Tree {
@@ -37,7 +37,7 @@ pub struct Tree {
 }
 
 /// A node in the SCPI command tree.
-/// 
+///
 /// Each node can have:
 /// - Children nodes representing the next part of a command
 /// - An optional command handler for when this node is a command endpoint
@@ -67,7 +67,7 @@ impl Tree {
     /// - "STATUS:EVENT?"
     /// - "STAT:EVENT?"
     /// - "EVENT?" (since STATUS is optional)
-    /// 
+    ///
     /// # Arguments
     /// * `cmd` - The command definition to insert
     ///
@@ -128,8 +128,11 @@ impl Tree {
             self.insert_at(node_id, &path[1..], cmd)?;
         } else {
             // We've reached the end of the path, register the command here
-            let node = self.items.get_mut(&id).expect("Node ID must exist in the tree");
-            
+            let node = self
+                .items
+                .get_mut(&id)
+                .expect("Node ID must exist in the tree");
+
             if cmd.command.is_query() {
                 // This is a query command (ends with '?')
                 if let Some(existing) = &node.query {

--- a/microscpi/src/commands.rs
+++ b/microscpi/src/commands.rs
@@ -115,10 +115,10 @@ pub trait StatusCommands: ErrorCommands {
         let value = self.status_registers().event_status;
         let mask = self.status_registers().event_status_enable;
         let result = value.intersection(mask).bits();
-        
+
         // Clear the event status register after reading (per SCPI standard)
         self.status_registers().event_status = EventStatus::empty();
-        
+
         Ok(result)
     }
 

--- a/microscpi/src/commands.rs
+++ b/microscpi/src/commands.rs
@@ -30,6 +30,18 @@ pub trait ErrorCommands {
             Ok((0, ""))
         }
     }
+
+    fn system_error_all(&mut self) -> Result<Vec<(i16, &'static str)>, Error> {
+        let errors = self.error_queue().all();
+        if !errors.is_empty() {
+            Ok(errors
+                .iter()
+                .map(|error| (error.number(), (*error).into()))
+                .collect::<Vec<_>>())
+        } else {
+            Ok(vec![(0, "")])
+        }
+    }
 }
 
 impl<I> ErrorHandler for I

--- a/microscpi/src/error_queue.rs
+++ b/microscpi/src/error_queue.rs
@@ -15,6 +15,8 @@ pub trait ErrorQueue: Default {
     /// Get and remove the error in the front of the error queue. If the queue
     /// is empty, [None] is returned.
     fn pop_error(&mut self) -> Option<Error>;
+    /// Get all errors list
+    fn all(&self) -> Vec<Error>;
     /// Clear the error queue.
     fn clear(&mut self);
 }
@@ -49,6 +51,10 @@ impl<const N: usize> ErrorQueue for StaticErrorQueue<N> {
 
     fn error_count(&self) -> usize {
         self.0.len()
+    }
+
+    fn all(&self) -> Vec<Error> {
+        self.0.iter().copied().collect()
     }
 
     fn clear(&mut self) {

--- a/microscpi/src/registers.rs
+++ b/microscpi/src/registers.rs
@@ -39,8 +39,8 @@ impl Default for StatusRegisters {
         Self {
             event_status: EventStatus::POWER_ON,
             event_status_enable: EventStatus::all(),
-            status_byte_enable: StatusByte::all() 
-                & !StatusByte::IMPLEMENTOR_DEFINED_1 
+            status_byte_enable: StatusByte::all()
+                & !StatusByte::IMPLEMENTOR_DEFINED_1
                 & !StatusByte::IMPLEMENTOR_DEFINED_0,
         }
     }


### PR DESCRIPTION
Proposal to add `SYSTem:ERRor:ALL?` support to list SCPI errors without cleaning the queue.

---

Ugly workaround we had before the patch (unreliable with async multi-clients) :

```rust
    // TODO: Migrate to microscpi library
    #[scpi(cmd = "SYSTem:ERRor:ALL?")]
    fn system_error_all_query(&mut self) -> Result<Vec<(i16, String)>, errors::api::Error> {
        let mut errors = Vec::new();
        while let Some(err) = self.error_queue().pop_error() {
            errors.push(err);
        }
        if errors.is_empty() {
            return Ok(vec![(0i16, "".to_string())]);
        }
        let response = errors
            .iter()
            .map(|error| (error.number(), error.to_string()))
            .collect::<Vec<_>>();
        for err in errors {
            self.error_queue().push_error(err);
        }
        Ok(response)
    }

```