### PR TITLE
feat(macros)!: return '-109 / MissingParameter' if parameters missing, '-108 / ParameterNotAllowed' if parameters not allowed

### DIFF
--- a/microscpi-macros/src/lib.rs
+++ b/microscpi-macros/src/lib.rs
@@ -111,6 +111,9 @@ impl CommandDefinition {
                 if args_len == 0 && #arg_count > 0 {
                     Err(::microscpi::Error::MissingParameter)
                 }
+                else if args_len > 0 && #arg_count == 0 {
+                    Err(::microscpi::Error::ParameterNotAllowed)
+                }
                 else if args_len != #arg_count {
                     Err(::microscpi::Error::UnexpectedNumberOfParameters)
                 }

--- a/microscpi-macros/src/lib.rs
+++ b/microscpi-macros/src/lib.rs
@@ -107,7 +107,11 @@ impl CommandDefinition {
 
         quote! {
             #command_id => {
-                if args.len() != #arg_count {
+                let args_len = args.len();
+                if args_len == 0 && #arg_count > 0 {
+                    Err(::microscpi::Error::MissingParameter)
+                }
+                else if args_len != #arg_count {
                     Err(::microscpi::Error::UnexpectedNumberOfParameters)
                 }
                 else {


### PR DESCRIPTION
The `-115 / UnexpectedNumberOfParameters` error is too unclear for this standard case :

- The `-109 / MissingParameter` standard SCPI errors was declared but never implemented / used.
- The `-108 / ParameterNotAllowed` standard SCPI errors was declared but never implemented / used.