### PR TITLE
feat(examples, fuzz, tests)!: fix IEEE 488.2 '*IDN?' without quotes

### DIFF
--- a/examples/doc/src/lib.rs
+++ b/examples/doc/src/lib.rs
@@ -1,4 +1,4 @@
-use microscpi::{self, ErrorHandler};
+use microscpi::{self, Characters, ErrorHandler};
 
 pub struct TestInterface {}
 
@@ -14,11 +14,11 @@ impl TestInterface {
     ///
     /// ```yaml
     /// unit: string
-    /// example: "ACME,Widget3000,1234,v1.02"
+    /// example: ACME,Widget3000,1234,v1.02
     /// ```
     #[scpi(cmd = "*IDN?")]
-    fn identify(&mut self) -> Result<&str, microscpi::Error> {
-        Ok("TEST,DEVICE,1234,1.0")
+    fn identify(&mut self) -> Result<Characters<'_>, microscpi::Error> {
+        Ok(Characters("TEST,DEVICE,1234,1.0"))
     }
 
     /// Sets a measurement parameter.

--- a/microscpi/fuzz/fuzz_targets/fuzz_interface.rs
+++ b/microscpi/fuzz/fuzz_targets/fuzz_interface.rs
@@ -4,7 +4,8 @@ use std::sync::OnceLock;
 
 use libfuzzer_sys::fuzz_target;
 use microscpi::{
-    self as scpi, ErrorCommands, ErrorQueue, Interface, StandardCommands, StaticErrorQueue,
+    self as scpi, Characters, ErrorCommands, ErrorQueue, Interface, StandardCommands,
+    StaticErrorQueue,
 };
 use tokio::runtime::Runtime;
 
@@ -50,9 +51,9 @@ impl TestInterface {
     }
 
     #[scpi(cmd = "*IDN?")]
-    pub async fn idn(&mut self) -> Result<&str, scpi::Error> {
+    pub async fn idn(&mut self) -> Result<Characters<'_>, scpi::Error> {
         self.result = Some(TestResult::IdnOk);
-        Ok("MICROSCPI,TEST,1,1.0")
+        Ok(Characters("MICROSCPI,TEST,1,1.0"))
     }
 
     #[scpi(cmd = "VALue:STRing?")]

--- a/microscpi/fuzz/fuzz_targets/fuzz_processing.rs
+++ b/microscpi/fuzz/fuzz_targets/fuzz_processing.rs
@@ -5,7 +5,8 @@ use std::sync::OnceLock;
 
 use libfuzzer_sys::fuzz_target;
 use microscpi::{
-    self as scpi, Adapter, ErrorCommands, ErrorQueue, Interface, StandardCommands, StaticErrorQueue,
+    self as scpi, Adapter, Characters, ErrorCommands, ErrorQueue, Interface, StandardCommands,
+    StaticErrorQueue,
 };
 use tokio::runtime::Runtime;
 
@@ -82,9 +83,9 @@ impl TestInterface {
     }
 
     #[scpi(cmd = "*IDN?")]
-    pub async fn idn(&mut self) -> Result<&str, scpi::Error> {
+    pub async fn idn(&mut self) -> Result<Characters<'_>, scpi::Error> {
         self.result = Some(TestResult::IdnOk);
-        Ok("MICROSCPI,TEST,1,1.0")
+        Ok(Characters("MICROSCPI,TEST,1,1.0"))
     }
 
     #[scpi(cmd = "VALue:STRing?")]

--- a/microscpi/tests/tests.rs
+++ b/microscpi/tests/tests.rs
@@ -1,6 +1,6 @@
 use microscpi::{
-    self as scpi, ErrorCommands, ErrorQueue, Interface, StandardCommands, StaticErrorQueue,
-    StatusCommands, StatusRegisters,
+    self as scpi, Characters, ErrorCommands, ErrorQueue, Interface, StandardCommands,
+    StaticErrorQueue, StatusCommands, StatusRegisters,
 };
 
 #[derive(Debug, PartialEq)]
@@ -41,9 +41,9 @@ impl TestInterface {
     }
 
     #[scpi(cmd = "*IDN?")]
-    pub async fn idn(&mut self) -> Result<&str, scpi::Error> {
+    pub async fn idn(&mut self) -> Result<Characters<'_>, scpi::Error> {
         self.result = Some(TestResult::IdnOk);
-        Ok("MICROSCPI,TEST,1,1.0")
+        Ok(Characters("MICROSCPI,TEST,1,1.0"))
     }
 
     #[scpi(cmd = "VALue:STRing?")]
@@ -306,7 +306,7 @@ async fn test_multiple_commands() {
     let (mut interface, mut output) = setup();
     interface.run(b"*RST\n*IDN?\n", &mut output).await;
     assert_eq!(interface.result, Some(TestResult::IdnOk));
-    assert_eq!(output, b"\"MICROSCPI,TEST,1,1.0\"\n");
+    assert_eq!(output, b"MICROSCPI,TEST,1,1.0\n");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Examples:
- Keysight Technologies,N5186A,US010.....,A.02.02
- Keysight Technologies,U2064XA,MY600.....,A.03.10

Tests updated and running fine.

Thanks !